### PR TITLE
Use non-deprecated venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 ```bash
-virtualenv venv
+python3 -m venv venv
 . venv/bin/activate
 pip install -r requirements.txt
 npm install


### PR DESCRIPTION
`virtualenv` command is deprecated and may use python2.x.

Instead use the command as recommended by the docs:

https://docs.python.org/3/library/venv.html